### PR TITLE
Ignore autographed stickers without readable name

### DIFF
--- a/backend/worker.js
+++ b/backend/worker.js
@@ -25,8 +25,7 @@ addEventListener('fetch', event => {
       const input = url.searchParams.get("input").toLowerCase();
       const isBackwards = url.searchParams.get("isBackwards") === 'true';
   
-      const response = await fetch('https://signature-checker.pages.dev/stickers.json');
-      const data = await response.json();
+      const data = await getStickers();
   
       let results = [];
       let remainingInput = input;
@@ -48,10 +47,7 @@ addEventListener('fetch', event => {
             const matchAgainst = item.matching ? item.matching.toLowerCase() : item.name.split('|').map(part => part.trim())[1].toLowerCase();
             const middlePartMain = matchAgainst.split(' ')[0];
   
-            if (item.description.toLowerCase().includes("autographed") || item.matching) {
-              return isBackwards ? middlePartMain.endsWith(partialInput) : middlePartMain.startsWith(partialInput);
-            }
-            return false;
+            return isBackwards ? middlePartMain.endsWith(partialInput) : middlePartMain.startsWith(partialInput);
           });
   
           if (filteredItems.length > 0) {
@@ -89,3 +85,11 @@ addEventListener('fetch', event => {
       });
     }
   }
+  
+  async function getStickers() {
+  const response = await fetch('https://signature-checker.pages.dev/stickers.json');
+  const allStickers = await response.json();
+  return allStickers
+    .filter(sticker => !sticker.ignore)
+    .filter(sticker => sticker.description.toLowerCase().includes("autographed") || sticker.matching);
+}


### PR DESCRIPTION
Some players has authographs without readable names:
- [chrisJ](https://steamcdn-a.akamaihd.net/apps/730/icons/econ/stickers/cologne2016/sig_chrisj_large.2184d219c130a0971d3477d49716874196bbf4da.png)
- [degster](https://steamcdn-a.akamaihd.net/apps/730/icons/econ/stickers/rio2022/sig_degster_large.aecb747964a9f77bda854e4223da464df11af6e1.png)

P.S. I also extracted method for getting stickers.