### PR TITLE
Add ability to select and remove stickers

### DIFF
--- a/index.css
+++ b/index.css
@@ -48,6 +48,33 @@ button:hover {
     flex: 1;
 }
 
+.selected-stickers-container {
+    width: 150px;
+    height: fit-content;
+    position: sticky;
+    top: 20px;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    padding: 10px 2px;
+    text-align: center;
+    font-weight: bold;
+}
+
+.selected-sticker-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    border-top: 1px solid #ccc;
+    padding: 6px 4px;
+    user-select: text;
+}
+
+.selected-sticker-info {
+    font-weight: normal;
+    font-size: small;
+}
+
 .result-group {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
- Added ability to select and remove stickers by clicking on them
- Added a sticky list where selected stickers will show up
- User can remove stickers from the list by clicking on them
- **This removes the market page redirect on click**, but it's replaced with a link to the market page under the selected sticker.

![Selected stickers list](https://github.com/cryck/sticker-composer/assets/11214356/bb135d3c-0c60-445c-ad75-6cdc7d89cae1)

#### The list is sticky and follows scroll:
![Sticky listj](https://github.com/cryck/sticker-composer/assets/11214356/f9b0ae67-8162-499f-b98c-3f7e0c162c2d)
