### PR TITLE
Better selected stickers view for mobile 

### DIFF
--- a/index.css
+++ b/index.css
@@ -39,6 +39,52 @@ button:hover {
     background-color: #0056b3;
 }
 
+.main-content {
+    position: relative; /* Needed for selected stickers list positioning  */
+}
+
+.selected-stickers-container {
+    height: 100%;
+    position: absolute;
+    top: 0;
+    right: -180px;
+}
+
+.selected-stickers-list {
+    width: 150px;
+    position: sticky;
+    top: 20px;
+    text-align: center;
+    font-weight: bold;
+    list-style: none;
+}
+
+.selected-sticker-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-bottom: 0; /* For avoiding double borders */
+    padding: 6px 4px;
+    user-select: text;
+}
+
+/* Round top and bottom items */
+.selected-sticker-item:first-child {
+    border-radius: 5px 5px 0 0;
+}
+
+.selected-sticker-item:last-child {
+    border-radius: 0 0 5px 5px;
+    border-bottom: 1px solid #ccc;;
+}
+
+.selected-sticker-info {
+    font-weight: normal;
+    font-size: small;
+}
+
 .results-container {
     margin-top: 20px;
     display: flex;
@@ -46,33 +92,6 @@ button:hover {
     gap: 20px;
     justify-content: center;
     flex: 1;
-}
-
-.selected-stickers-container {
-    width: 150px;
-    height: fit-content;
-    position: sticky;
-    top: 20px;
-    background: #fff;
-    border: 1px solid #ccc;
-    border-radius: 5px;
-    padding: 10px 2px;
-    text-align: center;
-    font-weight: bold;
-}
-
-.selected-sticker-wrapper {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    border-top: 1px solid #ccc;
-    padding: 6px 4px;
-    user-select: text;
-}
-
-.selected-sticker-info {
-    font-weight: normal;
-    font-size: small;
 }
 
 .result-group {
@@ -166,4 +185,57 @@ footer {
 footer p {
     margin: 0;
     padding: 0;
+}
+
+/* Mobile media queries*/
+@media only screen and (max-width: 768px) {
+    .selected-stickers-container {
+        position: sticky;
+        bottom: 0;
+    }
+
+    .selected-stickers-list {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+        padding: 0;
+    }
+
+    .selected-sticker-item {
+        width: 100%;
+    }
+
+    /* Hide title on mobile */
+    .selected-sticker-item:first-child {
+        display: none;
+    }
+
+    .selected-sticker-item {
+        font-size: small;
+        border-radius: 0;
+        border-bottom: 1px solid #ccc;
+    }
+    
+    .selected-sticker-item:nth-child(2) {
+        border-radius: 10px 0 0 0;
+    }
+    .selected-sticker-item:last-child {
+        border-radius: 0 10px 0 0;
+    }
+
+    .selected-sticker-item > .sticker-image {
+        max-width: 56px;
+    }
+
+    .selected-sticker-info {
+        font-size: x-small;
+    }
+
+    /* Hide tooltips on mobile */
+    .sticker-wrapper::after {
+        display: none;
+    }
+    .sticker-image::after{
+        display: none;
+    }
 }

--- a/index.html
+++ b/index.html
@@ -18,7 +18,12 @@
         </label>
         <button onclick="callWorker()">Search</button>
     </div>
-    <div id="results" class="results-container"></div>
+    <div class="main-content">
+        <div id="results" class="results-container"></div>
+        <div id="selectedStickersContainer" class="selected-stickers-container">
+            <ul id="selectedStickers" class="selected-stickers-list"></ul>
+        </div>
+    </div>
 
     <footer>
         Made by <a href="https://twitter.com/cryck_">cryck</a> with contributions from <a href="https://github.com/cryck/sticker-composer/graphs/contributors">these</a> lovely people. 

--- a/script.js
+++ b/script.js
@@ -65,9 +65,8 @@ async function callWorker() {
                 infoMessageDiv.classList.add('info-message');
                 infoMessageDiv.textContent = "No matches found for your input. Try another search term.";
                 resultsDiv.appendChild(infoMessageDiv);
-            } else {
-                renderSelectedStickers(selectedStickers)
-            }
+            } 
+            renderSelectedStickers(selectedStickers)
     } catch (error) {
         console.error('Error fetching data:', error);
         alert('Failed to fetch data from the worker.');
@@ -83,7 +82,8 @@ document.getElementById('stickerInput').addEventListener('keypress', function(ev
 function renderSelectedStickers(selectedStickers) {
     const selectedStickersList = document.getElementById('selectedStickers');
     selectedStickersList.innerHTML = '';
-    
+    if(!selectedStickers.length) return
+
     const title = document.createElement('li');
     title.classList.add('selected-sticker-item');
     title.textContent = "Selected:";

--- a/script.js
+++ b/script.js
@@ -66,11 +66,6 @@ async function callWorker() {
                 infoMessageDiv.textContent = "No matches found for your input. Try another search term.";
                 resultsDiv.appendChild(infoMessageDiv);
             } else {
-                // Create and append selected stickers container
-                const selectedStickersList = document.createElement('ul');
-                selectedStickersList.id = 'selectedStickers';
-                selectedStickersList.classList.add('selected-stickers-container');
-                resultsDiv.appendChild(selectedStickersList);
                 renderSelectedStickers(selectedStickers)
             }
     } catch (error) {
@@ -88,11 +83,15 @@ document.getElementById('stickerInput').addEventListener('keypress', function(ev
 function renderSelectedStickers(selectedStickers) {
     const selectedStickersList = document.getElementById('selectedStickers');
     selectedStickersList.innerHTML = '';
-    selectedStickersList.textContent = "Selected:";
+    
+    const title = document.createElement('li');
+    title.classList.add('selected-sticker-item');
+    title.textContent = "Selected:";
+    selectedStickersList.appendChild(title);
 
     selectedStickers.forEach(selected => {
         const selectedStickerItem = document.createElement('li');
-        selectedStickerItem.classList.add('selected-sticker-wrapper');
+        selectedStickerItem.classList.add('selected-sticker-item');
         selectedStickerItem.textContent = selected.matchedPart.toUpperCase();
 
         if (selected.sticker) {


### PR DESCRIPTION
- Added styling to selected stickers list for mobile
- Added a separate element for the list title, so it can be hidden on mobile
- Added `main-content` container that contains the results and selected stickers
- Moved selected stickers list out of the results container to ensure it doesn't affect the layout 
- Removed hoverable tooltips on mobile since they were overflowing

#### These changes aim to make the mobile experience a bit better for now. Let me know if you have any questions or if something should be changed.

### Screenshots:
Selected stickers are now shown on the bottom of the screen on mobile
![Mobile selected stickers list](https://github.com/cryck/sticker-composer/assets/11214356/356e3e0f-a4c4-40fb-8e8d-1361dd15963a)

Selected stickers are now positioned next to the results on desktop, rather than being part of them
![New selected stickers list](https://github.com/cryck/sticker-composer/assets/11214356/4399de43-ffee-4c0d-98af-ab813fbef06c)