### PR TITLE
Fix not entire input matched being broken since new UI

### DIFF
--- a/index.css
+++ b/index.css
@@ -256,6 +256,11 @@ footer p {
     padding: 0;
 }
 
+#infoContainer {
+    margin: 10px 0;
+    text-align: center;
+}
+
 /* Mobile media queries*/
 @media only screen and (max-width: 768px) {
     .main-content {

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
                 </label>
             </div>
         </div>
-        
+        <div id="infoContainer"></div>
         <div class="page-content">
             <div class="main-content">
                 <div id="results" class="results-container"></div>

--- a/script.js
+++ b/script.js
@@ -55,14 +55,12 @@ async function callWorker() {
             const selectedStickersList = document.getElementById('selectedStickers');
 
             if (results.length <= 0) {
-                const message = results.map(x => x.matchedPart).join('') !== inputVal
-                    ? "Could not match the entire input."
-                    : "No matches found for your input."
-
-                displayInfoMessage(resultsDiv, message, inputVal)
-
+                displayInfoMessage("No matches found for your input.", inputVal)
                 selectedStickersList.style.display = "none"
-            }  else {
+            } else if (results.map(x => x.matchedPart).join('') !== inputVal) {
+                displayInfoMessage("Could not match the entire input.", inputVal)
+                selectedStickersList.style.display = "none"
+            } else {
                 selectedStickersList.style.display = "block"
             }
             renderSelectedStickers(selectedStickers)
@@ -72,7 +70,7 @@ async function callWorker() {
     }
 }
 
-function displayInfoMessage(container, reason, inputVal) {
+function displayInfoMessage(reason, inputVal) {
     const div = document.createElement("div")
 
     const text = document.createElement('span');
@@ -87,7 +85,7 @@ function displayInfoMessage(container, reason, inputVal) {
     div.appendChild(text)
     div.appendChild(link);
 
-    container.appendChild(div)
+    document.getElementById('infoContainer').replaceChildren(div)
 }
 
 document.getElementById('stickerInput').addEventListener('keypress', function(event) {


### PR DESCRIPTION
Hey! #13 broke the checking of the entire input not being matched.
This was caused by this if statement which contains a bug: https://github.com/cryck/sticker-composer/blob/9a71069a7c9c5522b8de787508a7178d9bb30e9e/script.js#L57-L65

"Could not match the entire input." would never be displayed, as result is always empty in the if statement body. I fixed this by turning it back into an if, elseif, else statement
 
Before:
<img width="400" alt="Screenshot 2024-02-13 at 09 22 30" src="https://github.com/cryck/sticker-composer/assets/28759591/67b9270b-45e3-4dcd-9d91-091576b7e53e">

After:
<img width="400" alt="Screenshot 2024-02-13 at 09 37 57" src="https://github.com/cryck/sticker-composer/assets/28759591/8e42e500-ff8d-4ad0-9f5f-69a773a8c818">

Furthermore I added the InfoContainer back to allow it to display the results and the message at the same time (which is the case here)