### PR TITLE
Add back on top arrow

### DIFF
--- a/back-to-top.js
+++ b/back-to-top.js
@@ -1,0 +1,13 @@
+$(window).scroll(function() {
+  if ($(this).scrollTop() >= 100) {
+      $('#back-to-top').fadeIn(200);
+  } else {
+      $('#back-to-top').fadeOut(200);
+  }
+});
+
+$('#back-to-top').click(function() {
+  $('body,html').animate({
+      scrollTop : 0
+  }, 1000);
+});

--- a/index.css
+++ b/index.css
@@ -256,6 +256,11 @@ footer p {
     padding: 0;
 }
 
+#infoContainer {
+    margin: 10px 0;
+    text-align: center;
+}
+
 /* Mobile media queries*/
 @media only screen and (max-width: 768px) {
     .main-content {

--- a/index.css
+++ b/index.css
@@ -256,11 +256,6 @@ footer p {
     padding: 0;
 }
 
-#infoContainer {
-    margin: 10px 0;
-    text-align: center;
-}
-
 /* Mobile media queries*/
 @media only screen and (max-width: 768px) {
     .main-content {
@@ -324,4 +319,26 @@ footer p {
         align-items: stretch;
         justify-content: stretch;
     }
+}
+
+#back-to-top {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background: rgba(0, 0, 0, 0.7);
+    width: 50px;
+    height: 50px;
+    display: block;
+    text-decoration: none;
+    border-radius: 35px;
+    display: none;
+}
+
+#back-to-top i {
+    color: #fff;
+    margin: 0;
+    position: relative;
+    left: 16px;
+    top: 13px;
+    font-size: 19px;
 }

--- a/index.html
+++ b/index.html
@@ -15,20 +15,20 @@
             <h1 class="title">CS Sticker</h1>
             <h2 class="subTitle">Counter-Strike 2 - Sticker Craft Generator</h2>
         </div>
-    
+
         <div class="search-container">
             <div class="input-group">
                 <input type="text" id="stickerInput" placeholder="Enter sticker name">
                 <button onclick="callWorker()">Generate</button>
             </div>
-    
+
             <div>
                 <label>
                     <input type="checkbox" id="isBackwards"> Search Backwards
                 </label>
             </div>
         </div>
-        <div id="infoContainer"></div>
+
         <div class="page-content">
             <div class="main-content">
                 <div id="results" class="results-container"></div>
@@ -39,11 +39,16 @@
         </div>
     </div>
 
+    <a href="javascript:" id="back-to-top"><i class="icon-chevron-up"></i></a>
+    <link href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet">
+
     <footer>
         Made by <a href="https://twitter.com/cryck_">cryck</a> with contributions from <a href="https://github.com/cryck/sticker-composer/graphs/contributors">these</a> lovely people. 
-        Powered by Steam. 
+        Powered by Steam.
     </footer>
-    
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script src="/back-to-top.js"></script>
     <script src="/script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
                 </label>
             </div>
         </div>
+        <div id="infoContainer"></div>
 
         <div class="page-content">
             <div class="main-content">


### PR DESCRIPTION
## Hello 👋,
I open this PR to add back on top button.
When you use this website, and you start to scroll a little through the stickers, it becomes a long process to go back up. I find it quite nice that there is a back button at the top of the page. <br>

You just have to scroll 100px and the button will spawn:
![image](https://github.com/cryck/sticker-composer/assets/91665380/9abf14c2-8c99-43df-8042-e342b5637c6c)
