### PR TITLE
Fix deepsearch navigation

### DIFF
--- a/index.css
+++ b/index.css
@@ -123,10 +123,16 @@ label {
   height: 100%;
 }
 
-.selected-stickers-list {
-  width: 150px;
+.selected-stickers-wrapper {
   position: sticky;
   top: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.selected-stickers-list {
+  width: 150px;
   text-align: center;
   font-weight: bold;
   list-style: none;

--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
             <div class="main-content">
                 <div id="results" class="results-container"></div>
                 <div id="selectedStickersContainer" class="selected-stickers-container">
+                  <div class="selected-stickers-wrapper">
                     <ul id="selectedStickers" class="selected-stickers-list"></ul>
                     <div id="result-index-controls">
                       <p id="result-index-control-left" onclick="decrementResultIndex()">
@@ -55,6 +56,7 @@
                         >
                       </p>
                     </div>
+                  </div>
                 </div>
             </div>
           </div>

--- a/script.js
+++ b/script.js
@@ -28,7 +28,10 @@ function populateResults(resultIndex = 0) {
 
   if (currentResultsList.length > 1) {
     resultIndexControls.style.display = "flex"
+  } else {
+    resultIndexControls.style.display = "none"
   }
+  
   indexLabel.innerText = `${currentResultIndex + 1}/${currentResultsList.length}`
   const resultsDiv = document.getElementById("results")
   resultsDiv.innerHTML = ""

--- a/script.js
+++ b/script.js
@@ -5,7 +5,7 @@ const indexLabel = document.getElementById("result-index-label")
 function decrementResultIndex() {
   const newIndex = currentResultIndex - 1
 
-  if (newIndex > 0 && newIndex < currentResultsList.length - 1) {
+  if (newIndex >= 0 && newIndex < currentResultsList.length - 1) {
     currentResultIndex -= 1
     populateResults(currentResultIndex)
   }
@@ -13,7 +13,7 @@ function decrementResultIndex() {
 function incrementResultIndex() {
   const newIndex = currentResultIndex + 1
 
-  if (newIndex > 0 && newIndex < currentResultsList.length - 1) {
+  if (newIndex > 0 && newIndex <= currentResultsList.length - 1) {
     currentResultIndex += 1
     populateResults(currentResultIndex)
   }
@@ -29,7 +29,7 @@ function populateResults(resultIndex = 0) {
   if (currentResultsList.length > 1) {
     resultIndexControls.style.display = "flex"
   }
-  indexLabel.innerText = `${currentResultIndex}/${currentResultsList.length}`
+  indexLabel.innerText = `${currentResultIndex + 1}/${currentResultsList.length}`
   const resultsDiv = document.getElementById("results")
   resultsDiv.innerHTML = ""
 


### PR DESCRIPTION
- Fixed navigation buttons not incrementing/decrementing when next to first/last page
- Now shows current page starting from 1 instead of 0
- Made the navigation stick with selected stickers list when scrolling down
- Hide navigation if no results