### PR TITLE
Remove bash render from screenshot section

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -33,7 +33,6 @@ body:
       description: If applicable, add screenshots to help explain your problem.
       value: |
         ![DESCRIPTION](LINK.png)
-      render: bash
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
With the current issue template, it's impossible to add file to `screenshot` section.

Github [docs ](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#textarea) claims that's because we use `render` attribute.

@Queng123 let me know if you think there is better solution
