### PR TITLE
Use placeholder instead value in screenshot section

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -31,8 +31,7 @@ body:
     attributes:
       label: "Screenshots"
       description: If applicable, add screenshots to help explain your problem.
-      value: |
-        ![DESCRIPTION](LINK.png)
+      placeholder: ![DESCRIPTION](LINK.png)
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
One addition to #34.
We can use placeholder instead of adding non-existing file in the textarea:
![image](https://github.com/cryck/sticker-composer/assets/40705899/b3695718-4432-4638-a97d-b068b5f1aa83)

P.S. I've never played with templates so I didn't think about this earlier 😄 